### PR TITLE
Deprecated Packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "colors": "^1.4.0",
-    "discord.js": "^12.5.3",
-    "mongoose": "^5.11.15",
+    "discord.js": "<13.x",
+    "mongoose": "<6.x",
     "parse-ms": "^2.1.0",
     "ramda": "^0.27.1"
   }


### PR DESCRIPTION
Mongoose no longer requires options, they are implemented by default in v6: [https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options](https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options)

Discord.js v13 breaks everything... 😒